### PR TITLE
Support 24XX512 devices, set page sizes according to datasheet.

### DIFF
--- a/libraries/I2C_EEPROM/I2C_eeprom.h
+++ b/libraries/I2C_EEPROM/I2C_eeprom.h
@@ -38,6 +38,19 @@
 // comment next line to keep lib small (idea a read only lib?)
 #define I2C_EEPROM_EXTENDED
 
+enum device {
+	I2C_EEPROM_UNKNOWN,
+	I2C_EEPROM_2402,
+	I2C_EEPROM_2404,
+	I2C_EEPROM_2408,
+	I2C_EEPROM_2416,
+	I2C_EEPROM_2432,
+	I2C_EEPROM_2464,
+	I2C_EEPROM_24128,
+	I2C_EEPROM_24256,
+	I2C_EEPROM_24512,
+};
+
 class I2C_eeprom
 {
 public:
@@ -52,17 +65,17 @@ public:
      * It will try to guess page size and address word size based on the size of the device.
      * 
      * @param deviceAddress Byte address of the device.
-     * @param deviceSize    Max size in bytes of the device (divide your device size in Kbits by 8)
+     * @param device        EEPROM_2432 etc.  See enum above.
      */
-    I2C_eeprom(const uint8_t deviceAddress, const unsigned int deviceSize);
+    I2C_eeprom(const uint8_t deviceAddress, const enum device);
 
     void begin();
-    int writeByte(const uint16_t memoryAddress, const uint8_t value);
-    int writeBlock(const uint16_t memoryAddress, const uint8_t* buffer, const uint16_t length);
-    int setBlock(const uint16_t memoryAddress, const uint8_t value, const uint16_t length);
+    int writeByte(const uint32_t memoryAddress, const uint8_t value);
+    int writeBlock(const uint32_t memoryAddress, const uint8_t* buffer, const uint32_t length);
+    int setBlock(const uint32_t memoryAddress, const uint8_t value, const uint32_t length);
 
-    uint8_t readByte(const uint16_t memoryAddress);
-    uint16_t readBlock(const uint16_t memoryAddress, uint8_t* buffer, const uint16_t length);
+    uint8_t readByte(const uint32_t memoryAddress);
+    uint16_t readBlock(const uint32_t memoryAddress, uint8_t* buffer, const uint32_t length);
 
 #ifdef I2C_EEPROM_EXTENDED
     int determineSize();
@@ -81,11 +94,11 @@ private:
      * 
      * @param memoryAddress Address to write/read
      */
-    void _beginTransmission(const uint16_t memoryAddress);
+    void _beginTransmission(const uint32_t memoryAddress);
 
-    int _pageBlock(const uint16_t memoryAddress, const uint8_t* buffer, const uint16_t length, const bool incrBuffer);
-    int _WriteBlock(const uint16_t memoryAddress, const uint8_t* buffer, const uint8_t length);
-    uint8_t _ReadBlock(const uint16_t memoryAddress, uint8_t* buffer, const uint8_t length);
+    int _pageBlock(const uint32_t memoryAddress, const uint8_t* buffer, const uint32_t length, const bool incrBuffer);
+    int _WriteBlock(const uint32_t memoryAddress, const uint8_t* buffer, const uint8_t length);
+    uint8_t _ReadBlock(const uint32_t memoryAddress, uint8_t* buffer, const uint8_t length);
 
     void waitEEReady();
 };

--- a/libraries/I2C_EEPROM/keywords.txt
+++ b/libraries/I2C_EEPROM/keywords.txt
@@ -19,6 +19,21 @@ readBlock       KEYWORD2
 writeBlock      KEYWORD2
 determineSize   KEYWORD2
 
+######################################
+# Instances (KEYWORD2)
+#######################################
+
 #######################################
 # Constants (LITERAL1)
 #######################################
+
+I2C_EEPROM_UNKNOWN LITERAL1
+I2C_EEPROM_2402    LITERAL1
+I2C_EEPROM_2404    LITERAL1
+I2C_EEPROM_2408    LITERAL1
+I2C_EEPROM_2416    LITERAL1
+I2C_EEPROM_2432    LITERAL1
+I2C_EEPROM_2464    LITERAL1
+I2C_EEPROM_24128   LITERAL1
+I2C_EEPROM_24256   LITERAL1
+I2C_EEPROM_24512   LITERAL1


### PR DESCRIPTION
Rob,
I had some issues with addressing the 24LC512 devices.  Namely, while the uint16_t type can address the last octet in the device, it is not able to represent the entire length of the storage.  I also had some issues with address wrapping due to signedness of rv in determineSize limiting the maximum detected size to 32k or 16k (I can't remember now and I do not have the full set of devices on hand to test fully).

I have also re-worked the second constructor to take an enum... as the second argument to tell the library explicitly what part is involved so that the page size can be set correctly.  This unfortunately breaks the API so I'm not sure if you're happy with that change.

Additionally, the single argument constructor now calls the  two argument constructor with I2C_EEPROM_UNKNOWN which results in the page size being set to 8 octets. In my opinion this is the only safe page size since it should work with all the devices because a 128 octet page will always be aligned to an 8 octet boundary.  Perhaps the single argument constructor could attempt to determine part, but I don't believe that is entirely safe considering writes are involved and a poorly timed reset or power failure will result in data loss.
