### PR TITLE
Update dht::read() and dht::read11()

### DIFF
--- a/libraries/DHTlib/dht.cpp
+++ b/libraries/DHTlib/dht.cpp
@@ -51,20 +51,23 @@ int8_t dht::read11(uint8_t pin)
     // READ VALUES
     int8_t result = _readSensor(pin, DHTLIB_DHT11_WAKEUP, DHTLIB_DHT11_LEADING_ZEROS);
 
-    // these bits are always zero, masking them reduces errors.
-    bits[0] &= 0x7F;
-    bits[2] &= 0x7F;
-
-    // CONVERT AND STORE
-    humidity    = bits[0];  // bits[1] == 0;
-    temperature = bits[2];  // bits[3] == 0;
-
     // TEST CHECKSUM
     // bits[1] && bits[3] both 0
     uint8_t sum = bits[0] + bits[2];
     if (bits[4] != sum)
     {
         return DHTLIB_ERROR_CHECKSUM;
+    }
+    
+    if (result == DHTLIB_OK) // update temperature and humidity only when the result is okay
+    { 
+        // these bits are always zero, masking them reduces errors.
+        bits[0] &= 0x7F;
+        bits[2] &= 0x7F;
+    
+        // CONVERT AND STORE
+        humidity    = bits[0];  // bits[1] == 0;
+        temperature = bits[2];  // bits[3] == 0;
     }
     return result;
 }
@@ -74,24 +77,27 @@ int8_t dht::read(uint8_t pin)
     // READ VALUES
     int8_t result = _readSensor(pin, DHTLIB_DHT_WAKEUP, DHTLIB_DHT_LEADING_ZEROS);
 
-    // these bits are always zero, masking them reduces errors.
-    bits[0] &= 0x03;
-    bits[2] &= 0x83;
-
-    // CONVERT AND STORE
-    humidity = word(bits[0], bits[1]) * 0.1;
-    temperature = word(bits[2] & 0x7F, bits[3]) * 0.1;
-    if (bits[2] & 0x80)  // negative temperature
-    {
-        temperature = -temperature;
-    }
-
     // TEST CHECKSUM
     uint8_t sum = bits[0] + bits[1] + bits[2] + bits[3];
     if (bits[4] != sum)
     {
         return DHTLIB_ERROR_CHECKSUM;
     }
+    
+    if (result == DHTLIB_OK) // update temperature and humidity only when the result is okay
+    { 
+        // these bits are always zero, masking them reduces errors.
+        bits[0] &= 0x03;
+        bits[2] &= 0x83;
+    
+        // CONVERT AND STORE
+        humidity = word(bits[0], bits[1]) * 0.1;
+        temperature = word(bits[2] & 0x7F, bits[3]) * 0.1;
+        if (bits[2] & 0x80)  // negative temperature
+        {
+            temperature = -temperature;
+        }
+    } 
     return result;
 }
 


### PR DESCRIPTION
Currently temperature and humidity values are updated even when _readSensor() returns errors. It should only update temperature and humidity when the result is okay. Otherwise, it should just use the previous results.