### PR TITLE
Fix sensor reading for use withhin Realtime OS environments

### DIFF
--- a/libraries/DHTlib/dht.cpp
+++ b/libraries/DHTlib/dht.cpp
@@ -124,7 +124,7 @@ int8_t dht::_readSensor(uint8_t pin, uint8_t wakeupDelay, uint8_t leadingZeroBit
     // REQUEST SAMPLE
     pinMode(pin, OUTPUT);
     digitalWrite(pin, LOW); // T-be
-    delay(wakeupDelay);
+    delayMicroseconds(wakeupDelay*1000);
     digitalWrite(pin, HIGH); // T-go
     pinMode(pin, INPUT);
 


### PR DESCRIPTION
Replace delay() with delayMicroseconds() to let it work while interrupts are disabled.

In multihreaded environment (I used NilRTOS) its useful to disable interrupts while reading the sensors. E.g.:

```
nilSysLock(); // basically the same as cli()
int8_t const ret1( sensor1.read22(Sensor1_PIN) );
nilSysUnlock(); // basically the same as sei()
```


However the delay() used inside _readSensor() for the wakeup delay requires interrupts to be enabled. 
If one reads more than one sensor in a sequence the 2nd one gets spurious DHTLIB_ERROR_CONNECT errors due to timing issues with the wakeup delay().
They don't used to happen if interrupts are enabled, but then pre-emptive scheduling leads to other spurious errors since other threads might interrupt the sensor reading thread while doing serial communication with the sensor and disturb the timings of the protocoll.

Replacing delay() with delayMicroseconds() solved this issue for me.

 Tested with 2x DHT22 and Arduino Nano v3.