### PR TITLE
Add timing analysis, format output, limit execution cycles

### DIFF
--- a/libraries/DHTlib/examples/dht_tuning/dht_tuning.ino
+++ b/libraries/DHTlib/examples/dht_tuning/dht_tuning.ino
@@ -12,67 +12,82 @@
 
 dht DHT;
 
-#define DHT22_PIN 5
+#define DHT22_PIN 2
 
 void setup()
 {
-    Serial.begin(115200);
-    Serial.println("DHT TEST PROGRAM ");
-    Serial.print("LIBRARY VERSION: ");
-    Serial.println(DHT_LIB_VERSION);
-    Serial.println();
-    Serial.println("Type,\tstatus,\tHumidity (%),\tTemperature (C)\tTime (us)");
+  Serial.begin(115200);
+  Serial.println("DHT TEST PROGRAM ");
+  Serial.print("LIBRARY VERSION: ");
+  Serial.println(DHT_LIB_VERSION);
+  Serial.println();
+  Serial.println("Type,\tstatus,\t\tHumidity (%),\tTemperatur (C),\tT_Read (us)\tT_Cycle (us)\tT_Delay (us)");
 }
 
 int del = 500;
+uint32_t startRead = 0;
+uint32_t stopRead = 0;
+uint32_t startCycle = 0;
+uint32_t stopCycle = 0;
+uint32_t tempCycle = 0;
 
 void loop()
 {
+  while(del > 0){
     // READ DATA
     Serial.print("DHT22, \t");
-
-    uint32_t start = micros();
+    
+    startRead = micros();
     int chk = DHT.read22(DHT22_PIN);
-    uint32_t stop = micros();
+    stopRead = micros();
 
     switch (chk)
     {
     case DHTLIB_OK:
-        Serial.print("OK,\t");
-        del -= 10;
-        break;
+      Serial.print("OK,\t\t");
+      del -= 10;
+      break;
     case DHTLIB_ERROR_CHECKSUM:
-        Serial.print("Checksum error,\t");
-        break;
+      Serial.print("Checksum,\t");
+      break;
     case DHTLIB_ERROR_TIMEOUT:
-        Serial.print("Time out error,\t");
-        del += 10;
-        break;
+      Serial.print("Time out,\t");
+      del += 10;
+      break;
     case DHTLIB_ERROR_CONNECT:
-        Serial.print("Connect error,\t");
-        break;
+      Serial.print("Connect,\t");
+      break;
     case DHTLIB_ERROR_ACK_L:
-        Serial.print("Ack Low error,\t");
-        break;
+      Serial.print("Ack Low,\t");
+      break;
     case DHTLIB_ERROR_ACK_H:
-        Serial.print("Ack High error,\t");
-        break;
+      Serial.print("Ack High,\t");
+      break;
     default:
-        Serial.print("Unknown error,\t");
-        break;
+      Serial.print("Unknown,\t");
+      break;
     }
     // DISPLAY DATA
     Serial.print(DHT.humidity, 1);
-    Serial.print(",\t");
+    Serial.print(",\t\t");
     Serial.print(DHT.temperature, 1);
-    Serial.print(",\t");
-    Serial.print(stop - start);
-    Serial.print(",\t");
+    Serial.print(",\t\t");
+    Serial.print(stopRead - startRead);
+    Serial.print(",\t\t");
+    stopCycle = micros();
+    tempCycle = micros();
+    Serial.print(stopCycle - startCycle);
+    startCycle = tempCycle;
+    Serial.print(",\t\t");
     Serial.print(del);
+    Serial.print("000");
     Serial.println();
 
     delay(del);
+  }
+  while(1);
 }
 //
 // END OF FILE
 //
+


### PR DESCRIPTION
To increase the usefulness of the example, I added the measurement of
the complete cycle, which is the important figure. The reading time
itself, though interesting, is not the limiting factor according to the
datasheet.
Additionally, I updated the printing instructions to create a nicely
formatted output and limited the number cycles necessary to reach "del
== 0".