### PR TITLE
Fixed writing a pin can cause a input to become an output

### DIFF
--- a/libraries/PCF8574/PCF8574.cpp
+++ b/libraries/PCF8574/PCF8574.cpp
@@ -7,7 +7,7 @@
 //     URL:
 //
 // HISTORY:
-// 0.1.05 2016-04-28 Septillion
+// 0.1.07 2016-04-28 Septillion
 //        added dataOut so a write() doesn't read first, 
 //        possibly corrupting a input pin;
 //        fixed shift comment, should read 1..7;
@@ -36,7 +36,7 @@ PCF8574::PCF8574(uint8_t deviceAddress)
     // TWBR = 12; // 400KHz
 }
 
-//added 0.1.05
+//added 0.1.07
 void PCF8574::begin()
 {
   PCF8574::write8(0xFF);
@@ -67,7 +67,7 @@ uint8_t PCF8574::value()
     return _data;
 }
 
-//added 0.1.05
+//added 0.1.07
 uint8_t PCF8574::valueOut ()
 {
     return _dataOut;
@@ -104,6 +104,7 @@ void PCF8574::write(uint8_t pin, uint8_t value)
     PCF8574::write8(_dataOut);
 }
 
+//added 0.1.07
 uint8_t PCF8574::readButton8()
 {
   uint8_t temp = _dataOut;
@@ -114,6 +115,7 @@ uint8_t PCF8574::readButton8()
   return rtn;
 }
 
+//added 0.1.07
 uint8_t PCF8574::readButton(uint8_t pin)
 {
   uint8_t temp = _dataOut;

--- a/libraries/PCF8574/PCF8574.cpp
+++ b/libraries/PCF8574/PCF8574.cpp
@@ -7,6 +7,14 @@
 //     URL:
 //
 // HISTORY:
+// 0.1.05 2016-04-28 Septillion
+//        added dataOut so a write() doesn't read first, 
+//        possibly corrupting a input pin;
+//        fixed shift comment, should read 1..7;
+//        added begin() to be sure it's in a known state,
+//        states could be different if uC is reset and the PCF8574 isn't;
+//        added buttonRead() and buttonRead8() 
+//        which only effect the ouput while reading
 // 0.1.04 2015-05-09 removed ambiguity in read8()
 // 0.1.03 2015-03-02 address int -> uint8_t
 // 0.1.02 replaced ints with uint8_t to reduce footprint;
@@ -26,6 +34,12 @@ PCF8574::PCF8574(uint8_t deviceAddress)
     _address = deviceAddress;
     Wire.begin();
     // TWBR = 12; // 400KHz
+}
+
+//added 0.1.05
+void PCF8574::begin()
+{
+  PCF8574::write8(0xFF);
 }
 
 // removed Wire.beginTransmission(addr);
@@ -53,11 +67,17 @@ uint8_t PCF8574::value()
     return _data;
 }
 
+//added 0.1.05
+uint8_t PCF8574::valueOut ()
+{
+    return _dataOut;
+}
+
 void PCF8574::write8(uint8_t value)
 {
-    _data = value;
+    _dataOut = value;
     Wire.beginTransmission(_address);
-    Wire.write(_data);
+    Wire.write(_dataOut);
     _error = Wire.endTransmission();
 }
 
@@ -71,42 +91,65 @@ uint8_t PCF8574::read(uint8_t pin)
 // pin should be 0..7
 void PCF8574::write(uint8_t pin, uint8_t value)
 {
-    PCF8574::read8();
+    //Don't read because we could bring pulled low inputs into output state
+    //PCF8574::read8();
     if (value == LOW)
     {
-        _data &= ~(1<<pin);
+        _dataOut &= ~(1<<pin);
     }
     else
     {
-        _data |= (1<<pin);
+        _dataOut |= (1<<pin);
     }
-    PCF8574::write8(_data);
+    PCF8574::write8(_dataOut);
+}
+
+uint8_t PCF8574::readButton8()
+{
+  uint8_t temp = _dataOut;
+  PCF8574::begin();
+  uint8_t rtn = PCF8574::read8();
+  PCF8574::write8(temp);
+  
+  return rtn;
+}
+
+uint8_t PCF8574::readButton(uint8_t pin)
+{
+  uint8_t temp = _dataOut;
+  PCF8574::write(pin, HIGH);
+  uint8_t rtn = PCF8574::read(pin);
+  PCF8574::write8(temp);
+  
+  return rtn;
 }
 
 // pin should be 0..7
 void PCF8574::toggle(uint8_t pin)
-{
-    PCF8574::read8();
-    _data ^=  (1 << pin);
-    PCF8574::write8(_data);
+{   
+    //Same as write
+    //Don't read because that may upset pulled low inputs
+    //PCF8574::read8();
+    _dataOut ^=  (1 << pin);
+    PCF8574::write8(_dataOut);
 }
 
-// n should be 0..7
+// n should be 1..7
 void PCF8574::shiftRight(uint8_t n)
 {
     if (n == 0 || n > 7 ) return;
-    PCF8574::read8();
-    _data >>= n;
-    PCF8574::write8(_data);
+    //PCF8574::read8();
+    _dataOut >>= n;
+    PCF8574::write8(_dataOut);
 }
 
-// n should be 0..7
+// n should be 1..7
 void PCF8574::shiftLeft(uint8_t n)
 {
     if (n == 0 || n > 7) return;
-    PCF8574::read8();
-    _data <<= n;
-    PCF8574::write8(_data);
+    //PCF8574::read8();
+    _dataOut <<= n;
+    PCF8574::write8(_dataOut);
 }
 
 int PCF8574::lastError()

--- a/libraries/PCF8574/PCF8574.h
+++ b/libraries/PCF8574/PCF8574.h
@@ -25,13 +25,19 @@ class PCF8574
 {
 public:
     PCF8574(uint8_t deviceAddress);
+    
+    void begin();
 
     uint8_t read8();
     uint8_t read(uint8_t pin);
     uint8_t value();
+    uint8_t valueOut();
 
     void write8(uint8_t value);
     void write(uint8_t pin, uint8_t value);
+    
+    uint8_t readButton8();
+    uint8_t readButton(uint8_t pin);
 
     void toggle(uint8_t pin);
     void shiftRight(uint8_t n=1);
@@ -42,6 +48,7 @@ public:
 private:
     uint8_t _address;
     uint8_t _data;
+    uint8_t _dataOut = 0xFF;
     int _error;
 };
 


### PR DESCRIPTION
Fixes #38 
Also adds a begin() to be sure the PCF8574 is in knows state
Adds readButton() and readButton8() which set the pin high before reading and restore to last written state after that. Can be used if a pin is output and input at the same time. Reading it this way will not effect the output state.