### PR TITLE
buttonRead8() with mask function implementation

### DIFF
--- a/libraries/PCF8574/PCF8574.cpp
+++ b/libraries/PCF8574/PCF8574.cpp
@@ -38,7 +38,7 @@ PCF8574::PCF8574(const uint8_t deviceAddress)
     // TWBR = 12; // 400KHz
 
     _dataIn = 0;
-    _dataOut = 0;
+    _dataOut = 0xFF;
 
     _error = PCF8574_OK;
 }

--- a/libraries/PCF8574/PCF8574.cpp
+++ b/libraries/PCF8574/PCF8574.cpp
@@ -34,11 +34,12 @@
 PCF8574::PCF8574(const uint8_t deviceAddress)
 {
     _address = deviceAddress;
-    Wire.begin();
+    //Wire.begin();
     // TWBR = 12; // 400KHz
 
     _dataIn = 0;
     _dataOut = 0xFF;
+    _buttonMask = 0xFF;
 
     _error = PCF8574_OK;
 }
@@ -46,6 +47,7 @@ PCF8574::PCF8574(const uint8_t deviceAddress)
 //added 0.1.07
 void PCF8574::begin()
 {
+  Wire.begin();
   PCF8574::write8(0xFF);
 }
 
@@ -155,14 +157,14 @@ void PCF8574::rotateLeft(const uint8_t n)
     rotateRight(8- (n & 7));
 }
 
-//added 0.1.07 Septillion
-uint8_t PCF8574::readButton8()
+//added 0.1.07/08 Septillion
+uint8_t PCF8574::readButton8(const uint8_t mask)
 {
     uint8_t temp = _dataOut;
-    PCF8574::begin();
-    uint8_t rtn = PCF8574::read8();
+    PCF8574::write8(mask | _dataOut); 
+    PCF8574::read8();
     PCF8574::write8(temp);
-    return rtn;
+    return _dataIn;
 }
 
 //added 0.1.07 Septillion
@@ -178,6 +180,11 @@ uint8_t PCF8574::readButton(const uint8_t pin)
     uint8_t rtn = PCF8574::read(pin);
     PCF8574::write8(temp);
     return rtn;
+}
+
+//added 0.1.08 Septillion
+void PCF8574::setButtonMask(uint8_t mask){
+  _buttonMask = mask;
 }
 
 //

--- a/libraries/PCF8574/PCF8574.h
+++ b/libraries/PCF8574/PCF8574.h
@@ -41,9 +41,11 @@ public:
     void write(const uint8_t pin, const uint8_t value);
     uint8_t valueOut() const { return _dataOut; }
 
-    //added 0.1.07 Septillion
-    uint8_t readButton8();
+    //added 0.1.07/08 Septillion
+    inline uint8_t readButton8(){ PCF8574::readButton8(_buttonMask);}
+    uint8_t readButton8(const uint8_t mask);
     uint8_t readButton(const uint8_t pin);
+    void setButtonMask(uint8_t mask);
 
     // rotate, shift, toggle expect all lines are output
     void toggle(const uint8_t pin);
@@ -59,6 +61,7 @@ private:
     uint8_t _address;
     uint8_t _dataIn;
     uint8_t _dataOut;
+    uint8_t _buttonMask;
     int _error;
 };
 

--- a/libraries/PCF8574/examples/PCF8574_test/PCF8574_test.ino
+++ b/libraries/PCF8574/examples/PCF8574_test/PCF8574_test.ino
@@ -17,6 +17,8 @@ void setup()
   Serial.begin(9600);
   Serial.print("PCF8574_test version: ");
   Serial.println(PCF8574_LIB_VERSION);
+  
+  PCF_01.begin();
 
   int x = PCF_01.read8();
   Serial.print("Read ");

--- a/libraries/PCF8574/examples/PCF8574_test1/PCF8574_test1.ino
+++ b/libraries/PCF8574/examples/PCF8574_test1/PCF8574_test1.ino
@@ -17,6 +17,9 @@ void setup()
 {
   Serial.begin(115200);
   Serial.println("\nTEST PCF8574\n");
+  
+  PCF_38.begin();
+  PCF_39.begin();
    
   uint8_t value = PCF_38.read8();
   Serial.print("#38:\t");

--- a/libraries/PCF8574/examples/PCF8574_test2/PCF8574_test2.ino
+++ b/libraries/PCF8574/examples/PCF8574_test2/PCF8574_test2.ino
@@ -17,6 +17,8 @@ void setup()
     Serial.begin(115200);
     Serial.print("\npcf8574_test2.ino\nlib version: ");
     Serial.println(PCF8574_LIB_VERSION);
+    
+    PCF_39.begin();
 
     PCF_39.write(0, 1);
     for (int i=0; i<7; i++)

--- a/libraries/PCF8574/examples/buttonRead/buttonRead.ino
+++ b/libraries/PCF8574/examples/buttonRead/buttonRead.ino
@@ -1,0 +1,73 @@
+/**
+ *  @file
+ *  @Author Septillion (https://github.com/sseptillion)
+ *  @date 2016-05-20
+ *  @brief Example how to use buttonRead()
+ *  
+ *  Because of the quasi-bidirectional port on the PCF8574 it's 
+ *  possible to use the same pin as input and output at the same time.
+ *  
+ *  For this, connect the LED (or other device) between Vcc and the pin and
+ *  a button between GND and the pin.
+ *  
+ *  In order to read the pin the output is shortly (460us @ normal I2C speed)
+ *  set high during the read. So only use devices that can handle the small break
+ *  in state. It's not visable for the human eye with a LED.
+ *  
+ *  buttonRead() can also be used for pins that are input only.
+ *  
+ *  In this example pin 0 of the PCF8574 (address 0x20) is used to blink a 
+ *  LED but at the same time it can be used to toggle the onboard LED of 
+ *  the Arduino.
+ *  
+ *  NOTE: The button will affect the LED on the same pin. The led will light up 
+ *  no matter the set output state when you press the button.
+ */
+
+#include <PCF8574.h>
+#include <Wire.h>
+
+PCF8574 pcf20(0x20);
+
+const byte onboardLed = 13;
+const byte PcfButtonLedPin = 0;
+
+unsigned int blinkMillis;
+unsigned int buttonMillis;
+
+void setup() {
+  Serial.begin(115200);
+  pcf20.begin();
+  
+  pinMode(onboardLed, OUTPUT);
+}
+
+void loop() {
+  static bool state;
+  unsigned int currentMillis = millis();
+  
+  //Limit button read to 20 times a second
+  //Fast enough for most buttons 
+  //but this way you don't have a dimmer output because it's blanked during button read
+  //a read takes 460us t 16Mhz Arduino and normal I2C speed.
+  if(currentMillis - buttonMillis >= 50){
+    buttonMillis = currentMillis;
+    
+    if(state != pcf20.readButton(PcfButtonLedPin)){
+      if(state){
+        //toggle the LED
+        digitalWrite(onboardLed, !digitalRead(onboardLed));
+      }
+      state = !state;
+    }
+  }
+  
+  //Lets blink the same output
+  if(currentMillis - blinkMillis >= 500){
+    //Update time
+    blinkMillis = currentMillis;
+    
+    pcf20.toggle(PcfButtonLedPin);
+    Serial.println(pcf20.read8(), BIN);
+  }
+}

--- a/libraries/PCF8574/examples/buttonRead8/buttonRead8.ino
+++ b/libraries/PCF8574/examples/buttonRead8/buttonRead8.ino
@@ -1,0 +1,88 @@
+/**
+ *  @file
+ *  @Author Septillion (https://github.com/sseptillion)
+ *  @date 2016-05-20
+ *  @brief Example how to use buttonRead8()
+ *  
+ *  buttonRead8() works the same as buttonRead() but works on all 
+ *  pins simultaneous. You can give a mask as parameter to decide which 
+ *  pins are affected (aka, made high for a short periode) during 
+ *  a buttonRead8(). 
+ *  
+ *  The mask can also be set with setButtonMask(mask). Calling buttonRead8() 
+ *  after that will be the same as calling buttonRead8(mask).
+ *  
+ *  ButtonRead8() can also be used for pins that are input only.
+ *  
+ *  In this example pin 0 of the PCF8574 (address 0x20) is used to blink a 
+ *  LED but at the same time it can be used to toggle the onboard LED of 
+ *  the Arduino.
+ *  
+ *  Pin 1 is also toggle but isn't affected by the buttonRead8();
+ *  
+ *  NOTE: The button will affect the LED on the same pin. The led will light up 
+ *  no matter the set output state when you press the button.
+ */
+
+#include <PCF8574.h>
+#include <Wire.h>
+
+PCF8574 pcf20(0x20);
+
+const byte onboardLed = 13;
+const byte PcfButtonLedPin = 0;
+const byte PcfLedPin = 1;
+
+unsigned int blinkMillis;
+unsigned int buttonMillis;
+
+void setup() {
+  Serial.begin(115200);
+  pcf20.begin();
+  
+  pinMode(onboardLed, OUTPUT);
+  
+  //As alternative to adding the mask to buttonRead8() every time
+  //you can set it once.
+  //Without setting a mask buttonRead8() will effect ALL pins.
+  //Not a problem when using things like LEDs.
+  //pcf20.setButtonMask(_BV(PcfButtonLedPin));
+}
+
+void loop() {
+  static bool state;
+  unsigned int currentMillis = millis();
+  
+  //Limit button read to 20 times a second
+  //Fast enough for most buttons 
+  //but this way you don't have a dimmer output because it's blanked during button read
+  //a read takes 460us t 16Mhz Arduino and normal I2C speed.
+  if(currentMillis - buttonMillis >= 50){
+    buttonMillis = currentMillis;
+    
+    //read all states but only force PcfButtonLedPin HIGH during the 
+    //buttonRead8()
+    //Alternativly the mask could have been set with setButtonMask().
+    //Then the mask can be omitted here. See setup()
+    byte inputStates = pcf20.readButton8(_BV(PcfButtonLedPin));
+    
+    //check the bit of PcfButtonLedPin
+    if(state != bitRead(inputStates, PcfButtonLedPin)){
+      if(state){
+        //toggle the LED
+        digitalWrite(onboardLed, !digitalRead(onboardLed));
+      }
+      state = !state;
+    }
+  }
+  
+  //Lets blink the same output
+  if(currentMillis - blinkMillis >= 500){
+    //Update time
+    blinkMillis = currentMillis;
+    
+    pcf20.toggle(PcfButtonLedPin);
+    pcf20.toggle(PcfLedPin);
+    Serial.println(pcf20.read8(), BIN);
+  }
+}

--- a/libraries/PCF8574/notes.txt
+++ b/libraries/PCF8574/notes.txt
@@ -6,5 +6,5 @@ On some platforms (reported on an ESP8266) the PCF8574 constructor is causing pr
 
 Solution is moving the call to Wire.begin() from the constructor to void setup() before any call to an PCF8574 object.
 
-This might be fixed in the future. 
+FIXED in 0.1.08 @ 2016-05-20
 


### PR DESCRIPTION
Fixes #38 in more extend.

Adds a masking function to buttonRead8().

Adds examples for buttonRead() and buttonRead8().

Fixes wire.begin() object creation mis-order by moving it to begin().