### PR TITLE
Fix loop to allow searching for more than one device

### DIFF
--- a/sketches/oneWireSearch/oneWireSearch.ino
+++ b/sketches/oneWireSearch/oneWireSearch.ino
@@ -52,6 +52,7 @@ uint8_t findDevices(int pin)
     Serial.print("\nuint8_t pin");
     Serial.print(pin, DEC);
     Serial.println("[][8] = {");
+    do
     {
       count++;
       Serial.println("  {");


### PR DESCRIPTION
Before this fix - seems only empty statement after `while` condition was executed.
Please consult [cppreference](http://en.cppreference.com/w/cpp/language/do) for details.