### PR TITLE
Updates status output in dht22_test

### DIFF
--- a/libraries/DHTlib/examples/dht22_test/dht22_test.ino
+++ b/libraries/DHTlib/examples/dht22_test/dht22_test.ino
@@ -92,7 +92,7 @@ void loop()
 
     if (stat.total % 20 == 0)
     {
-        Serial.println("\nTOT\tOK\tCRC\tTO\tUNK");
+        Serial.println("\nTOT\tOK\tCRC\tTO\tCON\tACK_L\tACK_H\tUNK");
         Serial.print(stat.total);
         Serial.print("\t");
         Serial.print(stat.ok);


### PR DESCRIPTION
Previously the status output from this demo would look like this:

```
TOT	OK	CRC	TO	UNK
20	20	0	0	0	0	0	0
```

This incorrectly identifies the 5th value as `unknown` when it's actually `connect` and does not label the last 3 values.

I updated the header so that the output is properly

 
```
TOT	OK	CRC	TO	CON	ACK_L	ACK_H	UNK
20	20	0	0	0	0	0	0
```
