### PR TITLE
Use correct architecture value in library.properties

### DIFF
--- a/libraries/AvrHeap/library.properties
+++ b/libraries/AvrHeap/library.properties
@@ -6,4 +6,4 @@ sentence=Library to runtime analyze the structure of the heap (AVR328).
 paragraph= 
 category=Other
 url=https://github.com/RobTillaart/Arduino/Libraries/AvrHeap
-architectures=atmelavr
+architectures=avr

--- a/libraries/DHTlib/library.properties
+++ b/libraries/DHTlib/library.properties
@@ -6,4 +6,4 @@ sentence=Optimized Library for DHT Temperature & Humidity Sensor on AVR only.
 paragraph= 
 category=Sensors
 url=https://github.com/RobTillaart/Arduino/Libraries/
-architectures=atmelavr
+architectures=avr


### PR DESCRIPTION
Incorrect `architecture` value causes the warning:
```
WARNING: library AVRHeap claims to run on [atmelavr] architecture(s) and may be incompatible with your current board which runs on [avr] architecture(s).
```
and
```
WARNING: library DHTlib claims to run on [atmelavr] architecture(s) and may be incompatible with your current board which runs on [avr] architecture(s).
```