### PR TITLE
Use semver compliant versions in library.properties

### DIFF
--- a/libraries/AD524X/library.properties
+++ b/libraries/AD524X/library.properties
@@ -1,5 +1,5 @@
 name=AD524X
-version=0.1.03
+version=0.1.3
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Arduino Library for AD524X

--- a/libraries/AnalogPin/library.properties
+++ b/libraries/AnalogPin/library.properties
@@ -1,5 +1,5 @@
 name=AnalogPin
-version=0.1.04
+version=0.1.4
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Arduino Library for AD524X

--- a/libraries/Angle/library.properties
+++ b/libraries/Angle/library.properties
@@ -1,5 +1,5 @@
 name=Angle
-version=0.1.06
+version=0.1.6
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Library to convert between floating point angle to minutes hours representation.

--- a/libraries/AvrHeap/library.properties
+++ b/libraries/AvrHeap/library.properties
@@ -1,5 +1,5 @@
 name=AvrHeap
-version=0.1.04
+version=0.1.4
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Library to runtime analyze the structure of the heap (AVR328).

--- a/libraries/BitArray/library.properties
+++ b/libraries/BitArray/library.properties
@@ -1,5 +1,5 @@
 name=BitArray
-version=0.1.07
+version=0.1.7
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Library to make a compact array of objects with a size expressed in bits. typically 1..10 

--- a/libraries/Complex/library.properties
+++ b/libraries/Complex/library.properties
@@ -1,5 +1,5 @@
 name=Complex
-version=0.1.09
+version=0.1.9
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Library for Complex math. 

--- a/libraries/CountDown/library.properties
+++ b/libraries/CountDown/library.properties
@@ -1,5 +1,5 @@
 name=CountDown
-version=0.1.00
+version=0.1.0
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Library to implement a CountDown clock (in SW no HW). 

--- a/libraries/Cozir/library.properties
+++ b/libraries/Cozir/library.properties
@@ -1,5 +1,5 @@
 name=Cozir
-version=0.1.05
+version=0.1.5
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Library for COZIR range of CO2 sensors for Arduino. Polling mode only. 

--- a/libraries/DistanceTable/library.properties
+++ b/libraries/DistanceTable/library.properties
@@ -1,5 +1,5 @@
 name=DistanceTable
-version=0.1.01
+version=0.1.1
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Library for a memory efficient DistanceTable for Arduino. 

--- a/libraries/FastMap/library.properties
+++ b/libraries/FastMap/library.properties
@@ -1,5 +1,5 @@
 name=FastMap
-version=0.1.06
+version=0.1.6
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Library with fast map function for Arduino. 

--- a/libraries/Fraction/library.properties
+++ b/libraries/Fraction/library.properties
@@ -1,5 +1,5 @@
 name=Fraction
-version=0.1.07
+version=0.1.7
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Library for using fractions. 

--- a/libraries/FunctionGenerator/library.properties
+++ b/libraries/FunctionGenerator/library.properties
@@ -1,5 +1,5 @@
 name=FunctionGenerator
-version=0.1.04
+version=0.1.4
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Experimental library for waveform generation (SW). 

--- a/libraries/Histogram/library.properties
+++ b/libraries/Histogram/library.properties
@@ -1,5 +1,5 @@
 name=Histogram
-version=0.1.03
+version=0.1.3
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Library for creating histogram math.

--- a/libraries/IEEE754tools/library.properties
+++ b/libraries/IEEE754tools/library.properties
@@ -1,5 +1,5 @@
 name=IEEE754tools
-version=0.1.03
+version=0.1.3
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Helper functions for IEEE 754 floating point format.

--- a/libraries/MAX31855/library.properties
+++ b/libraries/MAX31855/library.properties
@@ -1,5 +1,5 @@
 name=MAX31855
-version=0.1.08
+version=0.1.8
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Library for MAX31855 Thermocouple.

--- a/libraries/MS5611/library.properties
+++ b/libraries/MS5611/library.properties
@@ -1,5 +1,5 @@
 name=MS5611
-version=0.1.05
+version=0.1.5
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Experimental library for MS5611 Temperature & Pressure for Arduino.

--- a/libraries/MultiMap/library.properties
+++ b/libraries/MultiMap/library.properties
@@ -1,5 +1,5 @@
 name=MultiMap
-version=0.1.00
+version=0.1.0
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Library for fast non-linear interpolation by means of two arrays. 

--- a/libraries/NibbleArray/library.properties
+++ b/libraries/NibbleArray/library.properties
@@ -1,5 +1,5 @@
 name=NibbleArray
-version=0.1.00
+version=0.1.0
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Library to implement a compact array of nibbles (4 bit).

--- a/libraries/PCA9685/library.properties
+++ b/libraries/PCA9685/library.properties
@@ -1,5 +1,5 @@
 name=PCA9685
-version=0.1.00
+version=0.1.0
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Library for PCA9685 PWM. 

--- a/libraries/Par27979/library.properties
+++ b/libraries/Par27979/library.properties
@@ -1,5 +1,5 @@
 name=Par27979
-version=0.1.00
+version=0.1.0
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Defines for Parallax 27979 serial display. 

--- a/libraries/ParPrinter/library.properties
+++ b/libraries/ParPrinter/library.properties
@@ -1,5 +1,5 @@
 name=ParPrinter
-version=0.1.00
+version=0.1.0
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Experimental (not complete) library to connect a parallel printer to Arduino. 

--- a/libraries/Radar/library.properties
+++ b/libraries/Radar/library.properties
@@ -1,5 +1,5 @@
 name=Radar
-version=0.1.01
+version=0.1.1
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Experimental library for a pan tilt radar. 

--- a/libraries/Set/library.properties
+++ b/libraries/Set/library.properties
@@ -1,5 +1,5 @@
 name=Set
-version=0.1.09
+version=0.1.9
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Library to implement SET datastructure.

--- a/libraries/StopWatch/library.properties
+++ b/libraries/StopWatch/library.properties
@@ -1,5 +1,5 @@
 name=StopWatch
-version=0.1.03
+version=0.1.3
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Library to implement a stopwatch.

--- a/libraries/Temperature/library.properties
+++ b/libraries/Temperature/library.properties
@@ -1,5 +1,5 @@
 name=Temperature
-version=0.1.00
+version=0.1.0
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Library with weather related functions. 

--- a/libraries/VT100/library.properties
+++ b/libraries/VT100/library.properties
@@ -1,5 +1,5 @@
 name=VT100
-version=0.1.00
+version=0.1.0
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Display codes (defines) for VT100 terminal emulators.

--- a/libraries/XMLWriter/library.properties
+++ b/libraries/XMLWriter/library.properties
@@ -1,5 +1,5 @@
 name=XMLWriter
-version=0.1.06
+version=0.1.6
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Library for writing XML files. 

--- a/libraries/hmc6532/library.properties
+++ b/libraries/hmc6532/library.properties
@@ -1,5 +1,5 @@
 name=HMC6532
-version=0.1.03
+version=0.1.3
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Experimental library for digital compass sensor


### PR DESCRIPTION
As stated in the [Arduino library specification](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification):
>Version should be [semver ](http://semver.org/)compliant

The leading zero is non-semver compliant and causes the Arduino IDE to display the warning:
```
Invalid version found: ...
```

Fixes https://github.com/RobTillaart/Arduino/issues/70