### PR TITLE
[DHTlib] Use correct architectures value in library.properties

### DIFF
--- a/libraries/DHTlib/library.properties
+++ b/libraries/DHTlib/library.properties
@@ -6,4 +6,4 @@ sentence=Optimized Library for DHT Temperature & Humidity Sensor on AVR only.
 paragraph= 
 category=Sensors
 url=https://github.com/RobTillaart/Arduino/tree/master/libraries
-architectures=atmelavr
+architectures=avr


### PR DESCRIPTION
The previous `architectures` value of `atmelavr` causes the example sketches to appear under **File > Examples > INCOMPATIBLE > DHTlib** and also a warning to be displayed during compilation of any sketch that includes the library:
```
WARNING: library DHTlib claims to run on (atmelavr) architecture(s) and may be incompatible with your current board which runs on (avr) architecture(s).
```
----
I had previously fixed this issue in https://github.com/RobTillaart/Arduino/commit/3e7660a5345fd226eec51f216ba8a32687d0519a but my fix was (I assume accidentally) reverted in https://github.com/RobTillaart/Arduino/commit/994981700d5cf9f9c8f694fcf908cc3d4d70eb5e.