### PR TITLE
[FRAM library] Use valid category in library.properties

### DIFF
--- a/libraries/FRAM/library.properties
+++ b/libraries/FRAM/library.properties
@@ -4,6 +4,6 @@ author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Library for FRAM for Arduino. 
 paragraph=
-category=Storage
+category=Data Storage
 url=https://github.com/RobTillaart/Arduino/tree/master/libraries/
 architectures=*


### PR DESCRIPTION
Previous property value caused the warning on every compilation:

WARNING: Category 'Storage' in library FRAM is not valid. Setting to 'Uncategorized'

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format