### PR TITLE
[DHTlib] Correct library.properties architectures value

### DIFF
--- a/libraries/DHTlib/library.properties
+++ b/libraries/DHTlib/library.properties
@@ -6,4 +6,4 @@ sentence=Optimized Library for DHT Temperature & Humidity Sensor on AVR only.
 paragraph= 
 category=Sensors
 url=https://github.com/RobTillaart/Arduino/tree/master/libraries
-architectures=atmelavr
+architectures=avr


### PR DESCRIPTION
The previous `architectures` value of atmelavr causes the example sketches to appear under **File > Examples > INCOMPATIBLE > DHTlib** and also a warning to be displayed during compilation of any sketch that includes the library:
```
WARNING: library DHTlib claims to run on (atmelavr) architecture(s) and may be incompatible with your current board which runs on (avr) architecture(s).
```
I originally fixed this in https://github.com/RobTillaart/Arduino/commit/3e7660a5345fd226eec51f216ba8a32687d0519a but it was reverted in https://github.com/RobTillaart/Arduino/commit/994981700d5cf9f9c8f694fcf908cc3d4d70eb5e then I fixed it again in https://github.com/RobTillaart/Arduino/commit/9a87037b3f45e1dc1276e64ead5cfcd3b3b16ec8 and again it was reverted by https://github.com/RobTillaart/Arduino/commit/d782be9946a63f794fa0eac0e714d5253fc14c31, then I fixed it again in https://github.com/RobTillaart/Arduino/commit/3309b8d42ba68b0fd088bc1704213f4e6a3fa23b but it was reverted again in https://github.com/RobTillaart/Arduino/commit/a145dc10afc1f4350b4cf31e648186ef0da765bb.

If there is a need for the `atmelavr` `architectures` value, it's possible to specify it in addition to `avr`:
```
architectures=avr,atmelavr
```