### PR TITLE
MCP4725: Remove erroneous const keyword from parameter

### DIFF
--- a/libraries/MCP4725/MCP4725.cpp
+++ b/libraries/MCP4725/MCP4725.cpp
@@ -187,7 +187,7 @@ bool MCP4725::RDY()
 
 // PAGE 19 DATASHEET
 // reg = MCP4725_DAC | MCP4725_EEPROM
-int MCP4725::writeRegisterMode(const uint16_t value, const uint8_t reg)
+int MCP4725::writeRegisterMode(const uint16_t value, uint8_t reg)
 {
     uint8_t h = (value / 16);
     uint8_t l = (value & 0x0F) << 4;

--- a/libraries/MCP4725/MCP4725.h
+++ b/libraries/MCP4725/MCP4725.h
@@ -82,7 +82,7 @@ private:
     int writeFastMode(const uint16_t value);
 
 #ifdef MCP4725_EXTENDED
-    int writeRegisterMode(const uint16_t value, const uint8_t reg);
+    int writeRegisterMode(const uint16_t value, uint8_t reg);
     uint8_t readRegister(uint8_t* buffer, const uint8_t length);
 #endif
 


### PR DESCRIPTION
Previously, when `MCP4725_EXTENDED` was defined, compilation of the library failed:
```
E:\arduino\libraries\MCP4725\MCP4725.cpp: In member function 'int MCP4725::writeRegisterMode(uint16_t, uint8_t)':

E:\arduino\libraries\MCP4725\MCP4725.cpp:195:9: error: assignment of read-only parameter 'reg'

     reg = reg | (_powerDownMode << 1);

         ^
```