### PR TITLE
Use default pins for ESP8266 with option to define custom pins

### DIFF
--- a/libraries/Max44009/Max44009.h
+++ b/libraries/Max44009/Max44009.h
@@ -40,9 +40,9 @@
 class Max44009
 {
 public:
-    // dataPin and clockPin are only used by ESP8266
+    // dataPin and clockPin can be used for ESP8266
     // for UNO ignore these (and its warning)
-    Max44009(const uint8_t address, const uint8_t dataPin = 5, const uint8_t clockPin = 4);
+    Max44009(const uint8_t address, const uint8_t dataPin = 255, const uint8_t clockPin = 255);
 
     float   getLux();
     int     getError();

--- a/libraries/Max44009/max44009.cpp
+++ b/libraries/Max44009/max44009.cpp
@@ -26,7 +26,7 @@
 Max44009::Max44009(const uint8_t address, const uint8_t dataPin, const uint8_t clockPin)
 {
     _address = address;
-    if ((dataPin < 255) && (dataPin < 255))
+    if ((dataPin < 255) && (clockPin < 255))
     {
         Wire.begin(dataPin, clockPin);
     } else {

--- a/libraries/Max44009/max44009.cpp
+++ b/libraries/Max44009/max44009.cpp
@@ -26,11 +26,12 @@
 Max44009::Max44009(const uint8_t address, const uint8_t dataPin, const uint8_t clockPin)
 {
     _address = address;
-#ifdef ESP8266
+    if ((dataPin < 255) && (dataPin < 255))
+    {
         Wire.begin(dataPin, clockPin);
-#else  // other platforms
+    } else {
         Wire.begin();
-#endif
+    }
     // TWBR = 12; // Wire.setClock(400000);
     _data = 0;
     _error = 0;


### PR DESCRIPTION
Use default pins for ESP8266 as default: no need to define default I2C pins.
Keep option to define custom pins for (ESP8266) users who can use custom pins.