### PR TITLE
Update PCA9635.h

### DIFF
--- a/libraries/PCA9635/PCA9635.h
+++ b/libraries/PCA9635/PCA9635.h
@@ -19,7 +19,7 @@
 
 #define PCA9635_MODE1       0x00
 #define PCA9635_MODE2       0x01
-#define PCA9635_PWM(x)      (0x02+(x))
+#define PCA9635_PWM(x)      (0x82+(x))
 
 #define PCA9635_GRPPWM      0x12
 #define PCA9635_GRPFREQ     0x13


### PR DESCRIPTION
Upper three bits of register address defines the register address incrementation flag. If this is not defined the array write is not possible.